### PR TITLE
Update install.sh

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,6 @@ To install, run the following (assuming you have curl and Go installed):
 Alternatively, you can use goinstall directly, but you must then set the
 CGO_CFLAGS and CGO_LDFLAGS environment variables:
     $ export CGO_CFLAGS=`llvm-config --cflags`
-    $ export CGO_LDFLAGS="`llvm-config --ldflags` -Wl,-L`llvm-config --libdir` -lLLVM-`llvm-config --version`"
+    $ export CGO_LDFLAGS="`llvm-config --ldflags` -Wl,-L`llvm-config --libdir` `llvm-config --libs interpreter all-targets bitwriter ipo engine`"
     $ goinstall github.com/axw/gollvm/llvm
 

--- a/README
+++ b/README
@@ -20,5 +20,5 @@ Alternatively, you can use goinstall directly, but you must then set the
 CGO_CFLAGS and CGO_LDFLAGS environment variables:
     $ export CGO_CFLAGS=`llvm-config --cflags`
     $ export CGO_LDFLAGS="`llvm-config --ldflags` -Wl,-L`llvm-config --libdir` `llvm-config --libs interpreter all-targets bitwriter ipo engine`"
-    $ goinstall github.com/axw/gollvm/llvm
+    $ go get github.com/axw/gollvm/llvm
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export CGO_CFLAGS="`llvm-config --cflags`"
-export CGO_LDFLAGS="`llvm-config --ldflags` -Wl,-L`llvm-config --libdir` -lLLVM-`llvm-config --version`"
+export CGO_LDFLAGS="`llvm-config --ldflags` -Wl,-L`llvm-config --libdir` `llvm-config --libs interpreter all-targets bitwriter ipo engine`"
 go install $* github.com/axw/gollvm/llvm


### PR DESCRIPTION
Hi Andrew,

Please, review this set of patches. I have updated install.sh and README to use llvm-config --libs instead of linking with libLLVM3.1svn.so (or, whatever version is installed).

Since llvm-config --libs is specifically designed for this purpose, it should work for every system.
