### PR TITLE
Remove StructLayout struct definition.

### DIFF
--- a/llvm/target.go
+++ b/llvm/target.go
@@ -13,9 +13,6 @@ type (
 	TargetData struct {
 		C C.LLVMTargetDataRef
 	}
-	StructLayout struct {
-		C C.LLVMStructLayoutRef
-	}
 	Target struct {
 		C C.LLVMTargetRef
 	}


### PR DESCRIPTION
This type is not and has never been used by the C bindings, furthermore it
has been removed by upstream.
