### PR TITLE
Removed update_llvm.sh dependence on GNU sed extensions

### DIFF
--- a/update_llvm.sh
+++ b/update_llvm.sh
@@ -25,7 +25,7 @@ target \
 gollvmdir=$(dirname "$0")
 
 llvmrev=$(grep run_update_llvm_sh_to_get_revision_ $gollvmdir/llvm_dep.go | \
-          sed -e 's/.*run_update_llvm_sh_to_get_revision_\([0-9]\+\).*/\1/g')
+          sed -E -e 's/.*run_update_llvm_sh_to_get_revision_([0-9]+.*)/\1/g')
 
 workdir=$gollvmdir/workdir
 llvmdir=$workdir/llvm


### PR DESCRIPTION
update_llvm.sh depends on a GNU extension to sed. This commit changes the script to rely on standard (POSIX ERE) features.
