### PR TITLE
Replace JIT bindings with MCJIT bindings

### DIFF
--- a/examples/factorial/factorial.go
+++ b/examples/factorial/factorial.go
@@ -6,8 +6,9 @@ import "fmt"
 import "github.com/go-llvm/llvm"
 
 func test() {
-	llvm.LinkInJIT()
+	llvm.LinkInMCJIT()
 	llvm.InitializeNativeTarget()
+	llvm.InitializeNativeAsmPrinter()
 
 	mod := llvm.NewModule("fac_module")
 
@@ -56,7 +57,7 @@ func test() {
 		return
 	}
 
-	engine, err := llvm.NewJITCompiler(mod, 2)
+	engine, err := llvm.NewMCJITCompiler(mod, llvm.MCJITCompilerOptions{OptLevel: 2})
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/executionengine_test.go
+++ b/executionengine_test.go
@@ -5,8 +5,9 @@ import (
 )
 
 func TestFactorial(t *testing.T) {
-	LinkInJIT()
+	LinkInMCJIT()
 	InitializeNativeTarget()
+	InitializeNativeAsmPrinter()
 
 	mod := NewModule("fac_module")
 
@@ -52,7 +53,7 @@ func TestFactorial(t *testing.T) {
 		return
 	}
 
-	engine, err := NewJITCompiler(mod, 2)
+	engine, err := NewMCJITCompiler(mod, MCJITCompilerOptions{OptLevel: 2})
 	if err != nil {
 		t.Errorf("Error creating JIT: %s", err)
 		return

--- a/target.go
+++ b/target.go
@@ -86,6 +86,14 @@ func InitializeNativeTarget() error {
 	return nil
 }
 
+func InitializeNativeAsmPrinter() error {
+	fail := C.LLVMInitializeNativeAsmPrinter()
+	if fail != 0 {
+		return initializeNativeTargetError
+	}
+	return nil
+}
+
 //-------------------------------------------------------------------------
 // llvm.TargetData
 //-------------------------------------------------------------------------

--- a/update_llvm.sh
+++ b/update_llvm.sh
@@ -15,9 +15,9 @@ instrumentation \
 interpreter \
 ipo \
 irreader \
-jit \
 linker \
 mc \
+mcjit \
 objcarcopts \
 option \
 profiledata \


### PR DESCRIPTION
The former is deprecated and is on track to be removed before LLVM 3.6.
