### PR TITLE
Roll LLVM to r218171

### DIFF
--- a/bitwriter.cpp
+++ b/bitwriter.cpp
@@ -18,5 +18,5 @@ LLVMMemoryBufferRef gollvm_WriteBitcodeToMemoryBuffer(LLVMModuleRef M) {
   raw_string_ostream OS(Data);
 
   WriteBitcodeToFile(unwrap(M), OS);
-  return wrap(MemoryBuffer::getMemBufferCopy(OS.str()));
+  return wrap(MemoryBuffer::getMemBufferCopy(OS.str()).release());
 }

--- a/llvm_dep.go
+++ b/llvm_dep.go
@@ -2,4 +2,4 @@
 
 package llvm
 
-var _ run_update_llvm_sh_to_get_revision_216572
+var _ run_update_llvm_sh_to_get_revision_218171


### PR DESCRIPTION
Incorporates support in LTO for IR in native object files, and a bug
fix for llgo #174.
